### PR TITLE
Make AMQP header properties available

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -98,6 +98,7 @@ AMQPServer.prototype.onReceiveData = function (ch, data) {
 
             try {
               do {
+                self.last_properties = data.properties;
                 processor.process(input, output);
                 transportWithData.commitPosition();
               } while (true);
@@ -125,6 +126,8 @@ AMQPServer.prototype.onReceiveData = function (ch, data) {
                 self.emit('error', err);
                 // stream.end();
               }
+            } finally {
+              self.last_properties = null;
             }
 
           })(content);

--- a/sample/server.js
+++ b/sample/server.js
@@ -27,9 +27,15 @@ var users = {};
 var server = ThriftAmqp.createServer(EchoService, {
 
   echo: function (msg, result) {
+    // The properties for the message must be read and saved immediately
+    // since they will be overwritten as soon as another message is processed
+    // which could happen as soon as we exit this function.
+    var last_properties = server.last_properties;
     console.log('msg:', msg);
     var timeout = 100;//Math.random() * 1000 || 0;
     setTimeout(function () {
+      console.log('messageId:', last_properties.messageId);
+      console.log('timestamp:', last_properties.timestamp);
       return result(null, msg);
     }, timeout);
   },


### PR DESCRIPTION
Unfortunately, there is no way to pass these headers directly to the
handler function since the handler function is called by the Thrift
generated code and that code has no way to add in extra parameters not
declared in the Thrift file. However, we do know that node is single
thread. So, what we can do is make the properties available as a
property on the AMQPServer object. From there, we can copy them into the
handler's body. Since Node is single threaded, we can be sure that
between the time that this variable is set on the AMQPServer object and
when the handler function initially runs, no other messages will be
processed. As soon as the handler exits, of course, another message may
be received - but sinced we've saved them to a variable in our handler
function, we don't have to worry about that.